### PR TITLE
Close websockets on close method

### DIFF
--- a/lcu_driver/connector.py
+++ b/lcu_driver/connector.py
@@ -77,9 +77,6 @@ class Connector(BaseConnector):
         :rtype: None
         """
         self._repeat_flag = False
-        if self.connection is not None:
-            await self.connection._close()
-        
 
 
 class MultipleClientConnector(BaseConnector):

--- a/lcu_driver/connector.py
+++ b/lcu_driver/connector.py
@@ -77,6 +77,9 @@ class Connector(BaseConnector):
         :rtype: None
         """
         self._repeat_flag = False
+        if self.connection is not None:
+            await self.connection._close()
+        
 
 
 class MultipleClientConnector(BaseConnector):


### PR DESCRIPTION
This allows the Connector.stop() method to close websocket connections and fully close the connector in the case you need to stop the connector without closing the league client.