### PR TITLE
Fix equals sign in command line arguments

### DIFF
--- a/lcu_driver/utils.py
+++ b/lcu_driver/utils.py
@@ -7,7 +7,7 @@ def parse_cmdline_args(cmdline_args) -> Dict[str, str]:
     cmdline_args_parsed = {}
     for cmdline_arg in cmdline_args:
         if len(cmdline_arg) > 0 and '=' in cmdline_arg:
-            key, value = cmdline_arg[2:].split('=')
+            key, value = cmdline_arg[2:].split('=', 1)
             cmdline_args_parsed[key] = value
     return cmdline_args_parsed
 


### PR DESCRIPTION
Fixes issue with extra equals signs causing parsing to fail in arguments