### PR TITLE
Skip over zombie processes

### DIFF
--- a/lcu_driver/utils.py
+++ b/lcu_driver/utils.py
@@ -1,6 +1,6 @@
 from typing import Dict, Generator
 
-from psutil import process_iter, Process
+from psutil import process_iter, Process, STATUS_ZOMBIE
 
 
 def parse_cmdline_args(cmdline_args) -> Dict[str, str]:
@@ -14,7 +14,7 @@ def parse_cmdline_args(cmdline_args) -> Dict[str, str]:
 
 def _return_ux_process() -> Generator[Process, None, None]:
     for process in process_iter():
-        if process.status() == psutil.STATUS_ZOMBIE:
+        if process.status() == STATUS_ZOMBIE:
             continue
 
         if process.name() in ['LeagueClientUx.exe', 'LeagueClientUx']:

--- a/lcu_driver/utils.py
+++ b/lcu_driver/utils.py
@@ -14,5 +14,8 @@ def parse_cmdline_args(cmdline_args) -> Dict[str, str]:
 
 def _return_ux_process() -> Generator[Process, None, None]:
     for process in process_iter():
+        if process.status() == psutil.STATUS_ZOMBIE:
+            continue
+
         if process.name() in ['LeagueClientUx.exe', 'LeagueClientUx']:
             yield process


### PR DESCRIPTION
Zombie processes will raise an exception when trying to access `process.name()`.

This causes this function to fail from completely unrelated circumstances. We should be able to safely ignore these processes. 