### PR TITLE
Additional detection for LeagueClientUx.exe to cover linux users.

### DIFF
--- a/lcu_driver/utils.py
+++ b/lcu_driver/utils.py
@@ -1,30 +1,28 @@
 from typing import Dict, Generator, List
 
-from psutil import STATUS_ZOMBIE, AccessDenied, NoSuchProcess, Process, process_iter
+from psutil import STATUS_ZOMBIE, Process, process_iter
 
 
 def parse_cmdline_args(cmdline_args) -> Dict[str, str]:
     cmdline_args_parsed = {}
     for cmdline_arg in cmdline_args:
-        if len(cmdline_arg) > 0 and '=' in cmdline_arg:
-            key, value = cmdline_arg[2:].split('=', 1)
+        if len(cmdline_arg) > 0 and "=" in cmdline_arg:
+            key, value = cmdline_arg[2:].split("=", 1)
             cmdline_args_parsed[key] = value
     return cmdline_args_parsed
 
 
 def _return_ux_process() -> Generator[Process, None, None]:
     for process in process_iter(attrs=["cmdline"]):
-        try:
-            if process.status() == STATUS_ZOMBIE:
-                continue
+        if process.status() == STATUS_ZOMBIE:
+            continue
 
-            cmdline: List[str] = process.info.get("cmdline", [])
+        cmdline: List[str] = process.info.get("cmdline", [])
 
-            if process.name() in ["LeagueClientUx.exe", "LeagueClientUx"]:
-                yield process
+        if process.name() in ["LeagueClientUx.exe", "LeagueClientUx"]:
+            yield process
 
-            if cmdline and cmdline[0].endswith("LeagueClientUx.exe"):
-                yield process
-
-        except (NoSuchProcess, AccessDenied):
-            pass
+        # Check cmdline for the executable, especially useful in Linux environments
+        # where process names might differ due to compatibility layers like wine.
+        if cmdline and cmdline[0].endswith("LeagueClientUx.exe"):
+            yield process

--- a/lcu_driver/utils.py
+++ b/lcu_driver/utils.py
@@ -17,5 +17,5 @@ def _return_ux_process() -> Generator[Process, None, None]:
         if process.status() == STATUS_ZOMBIE:
             continue
 
-        if process.name() in ['LeagueClientUx.exe', 'LeagueClientUx']:
+        if process.name() in ['LeagueClientUx.exe', 'LeagueClientUx', 'CrBrowserMain']:
             yield process


### PR DESCRIPTION
I tried running lcu-driver on Fedora/Nobara linux. when i play League from Lutris/Wine.
The processes that were looked for did not check "CrBrowserMain" causing me not being able to use the project on Linux.

I verified that it works with this change included on Linux, but i have not tested on Windows.. I doubt that it will cause any issues to include this process.

![image](https://github.com/sousa-andre/lcu-driver/assets/90850836/cf77e32c-b697-43ff-bd15-291282021302)
