### PR TITLE
avoid infinite loop when closing connection

### DIFF
--- a/lcu_driver/connection.py
+++ b/lcu_driver/connection.py
@@ -78,8 +78,8 @@ class Connection:
 
     async def _close(self):
         self.closed = True
-        await self._connector.run_event('close', self)
         self._connector.unregister_connection(self._lcu_pid)
+        await self._connector.run_event('close', self)
         await self.session.close()
 
     @property


### PR DESCRIPTION
```py
@connector.close
async def disconnect(_) -> None:
    print("The client have been closed!")
    await connector.stop()
```

This code causes infinite loops to occur.
![image](https://github.com/user-attachments/assets/ce491fc4-24c3-4441-bb86-5ea0563b31a5)


Swapping the order of the changed lines in this pr, fixes the issue.
![image](https://github.com/user-attachments/assets/e7457fd6-e03e-4454-9bc5-5836c0e79065)

